### PR TITLE
Re-enabled aarch and ppc64 builds again

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,10 +12,8 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 2
+  number: 3
   run_exports: spglib  # [not win]
-  # Build is currently failing for pypy and aarch64 or ppc64le due to a rpath issue:
-  skip: true  # [(python_impl == 'pypy') and (aarch64 or ppc64le)]
 
 requirements:
   build:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
As promised I re-enabled aarch and ppc64le here again. The builds of this PR will most probably fail.